### PR TITLE
Define kind in generateTutorial (publish.js)

### DIFF
--- a/publish.js
+++ b/publish.js
@@ -685,6 +685,7 @@ exports.publish = function (taffyData, opts, tutorials) {
     function generateTutorial(title, tutorial, filename) {
         var tutorialData = {
             title: title,
+            kind: null,
             header: tutorial.title,
             content: tutorial.parse(),
             children: tutorial.children


### PR DESCRIPTION
Thanks for sharing such a great template.

However, I had to define `kind` in `generateTutorial()` (publish.js) since adding a [tutorial](https://jsdoc.app/about-tutorials.html) caused  `<main>` (tmpl/layout.tmpl) to raise an error.

<details>
<summary>Click to show error message</summary>

```
undefined:44
 if (kind === 'source') { 
 ^

ReferenceError: kind is not defined
    at Template.eval (eval at template (/home/.../Projects/.../node_modules/underscore/underscore-node-f.cjs:924:14), <anonymous>:44:2)
    at Template.template (/home/.../Projects/.../node_modules/underscore/underscore-node-f.cjs:931:19)
    at Template.partial (/home/.../Projects/.../node_modules/jsdoc/lib/jsdoc/template.js:55:33)
    at Template.render (/home/.../Projects/.../node_modules/jsdoc/lib/jsdoc/template.js:74:28)
    at generateTutorial (/home/.../Projects/.../node_modules/tidy-jsdoc/publish.js:696:25)
    at /home/.../Projects/.../node_modules/tidy-jsdoc/publish.js:707:13
    at Array.forEach (<anonymous>)
    at saveChildren (/home/.../Projects/.../node_modules/tidy-jsdoc/publish.js:706:23)
    at Object.exports.publish (/home/.../Projects/.../node_modules/tidy-jsdoc/publish.js:711:5)
    at Object.module.exports.cli.generateDocs (/home/.../Projects/.../node_modules/jsdoc/cli.js:441:39)
    at Object.module.exports.cli.processParseResults (/home/.../Projects/.../node_modules/jsdoc/cli.js:392:24)
    at module.exports.cli.main (/home/.../Projects/.../node_modules/jsdoc/cli.js:235:18)
    at Object.module.exports.cli.runCommand (/home/.../Projects/.../node_modules/jsdoc/cli.js:186:9)
    at /home/.../Projects/.../node_modules/jsdoc/jsdoc.js:93:9
    at Object.<anonymous> (/home/.../Projects/.../node_modules/jsdoc/jsdoc.js:94:3)
    at Module._compile (internal/modules/cjs/loader.js:1063:30)
```
</details>

To work around the problem I simply set `kind: null`. It seems to work but you would know best.